### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Use the provided snapshots to quickly sync your Juno node with the current state
 
 | Version | Size | Block | Download Link |
 | ------- | ---- | ----- | ------------- |
-| **>=v0.6.0** | **4.6 GB** | **139043** | [**juno_goerli2_135973.tar**](https://juno-snapshots.nethermind.dev/goerli2/juno_goerli2_v0.6.0_139043.tar) |
+| **>=v0.6.0** | **4.6 GB** | **139043** | [**juno_goerli2_139043.tar**](https://juno-snapshots.nethermind.dev/goerli2/juno_goerli2_v0.6.0_139043.tar) |
 
 ### Run Juno Using Snapshot
 


### PR DESCRIPTION
In the section Run Juno Using Snapshot, under the "Goerli2" table, the download link label is juno_goerli2_135973.tar but the link provided is juno_goerli2_v0.6.0_139043.tar. You should ensure that the label and the link are consistent.